### PR TITLE
Change GSL pkg compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ NLopt = "76087f3c-5699-56af-9a33-bf431cd00edd"
 [compat]
 julia = "1"
 NLopt = "0.6"
-GSL = "0.5.1"
+GSL = "0.5.1 - 1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
The version of GSL is already at v1.0.1 that also included the installation of GSL_jll. 

So what I've done is:
- Made the changes that allow to use any version of GSL up to v1.1.0 (not included).
- Ran the tests => all passed.
- Ran some personal examples => seems to be all good.

If you are confident that any future versions of GSL will be compatible, then one could change to ` GSL = ">= 0.5.1" `.